### PR TITLE
Respect AuthenticationScheme

### DIFF
--- a/src/idunno.Authentication.Basic/BasicAuthenticationHandler.cs
+++ b/src/idunno.Authentication.Basic/BasicAuthenticationHandler.cs
@@ -17,7 +17,6 @@ namespace idunno.Authentication.Basic
 {
     internal class BasicAuthenticationHandler : AuthenticationHandler<BasicAuthenticationOptions>
     {
-        private const string _Scheme = "Basic";
 
         public BasicAuthenticationHandler(
             IOptionsMonitor<BasicAuthenticationOptions> options,
@@ -53,6 +52,7 @@ namespace idunno.Authentication.Basic
                 return AuthenticateResult.NoResult();
             }
 
+            var _Scheme = this.ClaimsIssuer ?? BasicAuthenticationDefaults.AuthenticationScheme;
             if (!authorizationHeader.StartsWith(_Scheme + ' ', StringComparison.OrdinalIgnoreCase))
             {
                 return AuthenticateResult.NoResult();
@@ -144,7 +144,7 @@ namespace idunno.Authentication.Basic
             else
             {
                 Response.StatusCode = 401;
-
+                var _Scheme = this.ClaimsIssuer ?? BasicAuthenticationDefaults.AuthenticationScheme;
                 var headerValue = _Scheme + $" realm=\"{Options.Realm}\"";
                 Response.Headers.Append(HeaderNames.WWWAuthenticate, headerValue);
             }


### PR DESCRIPTION
See #36

This has been tested on a simple Asp.Net Core 2.2 web application where I wanted to use basic auth but with a custom authentication schema to prevent ajax request to trigger a browser crentials popup. 

---------------------

While it is possible to use a custom scheme with

```
services.AddAuthentication("custom")
            .AddBasic("custom", options => { ... });
```

this is ignored by `idunno.BasicAuthenticationHandler`
and the const value of `BasicAuthenticationHandler._Scheme`
is used instead in `HandleAuthenticateAsync` and `HandleChallengeAsync`.

Since the configured scheme is stored in
`AuthenticationHandler<TOptions>.ClaimsIssuer`
this value should be used instead.

Checklists for Pull requests
----------------------------

About pull request itself:
- [X] I am submitting a pull request :)
- [x] I have already created an issue and referred to it in the commit message.
- [x] My submission does one logical thing only (one bugfix, one new feature). 
      If want to supply multiple logical changes, I will submit multiple pull requests.
- [ ] I have read and understood CONTRIBUTING guide

Commits:
- [x] My commits are logical, easily readable, with concise comments.

Licensing:
- [x] I am the author of submission or have been authorized by submission copyright holder to issue this pull request.

Branching:
- [x] My submission is based on master branch.
- [x] My submission is compatible with latest master branch updates (no conflicts, I did a rebase if it was necessary).
- [ ] The name of the branch I want to merge upstream is not 'master' (except for only the most trivial fixes, like typos and such).
- [ ] My branch name is *feature/my-new-not-for-productionfeature* (for new features).
- [ ] My branch name is *bugfix/i-fixed-your-crap-code* (for bugfixes).

Pull request description
------------------------